### PR TITLE
Feature/auth service/creating unit tests

### DIFF
--- a/backend/auth-service/src/main/java/com/cherkizon/auth/service/impl/AuthServiceImpl.java
+++ b/backend/auth-service/src/main/java/com/cherkizon/auth/service/impl/AuthServiceImpl.java
@@ -47,9 +47,9 @@ public class AuthServiceImpl implements AuthService {
         user.setPassword(passwordEncoder.encode(request.getPassword()));
         user.setRole(User.Role.USER);
 
-        userRepository.save(user);
+        User saved = userRepository.save(user);
         eventPublisher.publish(new UserCreatedDto(
-                user.getId(),
+                saved.getId(),
                 user.getUsername(),
                 request.getFirstName(),
                 request.getLastName(),

--- a/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/AuthServiceImplTest.java
+++ b/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/AuthServiceImplTest.java
@@ -1,0 +1,158 @@
+package com.cherkizon.auth.service.impl;
+
+import com.cherkizon.auth.dto.event.UserCreatedDto;
+import com.cherkizon.auth.dto.request.LoginRequest;
+import com.cherkizon.auth.dto.request.RegisterRequest;
+import com.cherkizon.auth.dto.request.RequestChangePasswordDto;
+import com.cherkizon.auth.dto.response.JwtResponse;
+import com.cherkizon.auth.entity.User;
+import com.cherkizon.auth.exception.InvalidPassword;
+import com.cherkizon.auth.exception.NotFoundException;
+import com.cherkizon.auth.exception.UserAlreadyExistsException;
+import com.cherkizon.auth.repository.UserRepository;
+import com.cherkizon.auth.service.EventPublisher;
+import com.cherkizon.auth.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AuthServiceImplTest {
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private EventPublisher eventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void register_successful() {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("test@mail.com");
+        request.setPassword("Password1");
+        request.setFirstName("John");
+        request.setLastName("Doe");
+        request.setPhone("+79991234567");
+
+        when(userRepository.findByUsername("test@mail.com")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("Password1")).thenReturn("hashedPassword");
+
+        authService.register(request);
+
+        verify(userRepository).save(argThat(user ->
+                user.getUsername().equals("test@mail.com") &&
+                        user.getPassword().equals("hashedPassword")
+        ));
+        verify(eventPublisher).publish(any(UserCreatedDto.class));
+    }
+
+    @Test
+    void register_userAlreadyExists() {
+        RegisterRequest request = new RegisterRequest();
+        request.setUsername("test@mail.com");
+
+        when(userRepository.findByUsername("test@mail.com")).thenReturn(Optional.of(new User()));
+
+        assertThrows(UserAlreadyExistsException.class, () -> authService.register(request));
+    }
+
+    @Test
+    void login_successful() {
+        LoginRequest request = new LoginRequest();
+        request.setUsername("user@mail.com");
+        request.setPassword("Password1");
+
+        User user = new User();
+        user.setUsername("user@mail.com");
+
+        Authentication auth = mock(Authentication.class);
+        when(authenticationManager.authenticate(any())).thenReturn(auth);
+        when(auth.getPrincipal()).thenReturn(user);
+
+        JwtResponse jwtResponse = new JwtResponse("access", "refresh", 1L, null);
+        when(jwtService.generateTokens(user)).thenReturn(jwtResponse);
+
+        JwtResponse response = authService.login(request);
+
+        assertEquals("access", response.accessToken());
+        assertEquals("refresh", response.refreshToken());
+    }
+
+    @Test
+    void refreshToken_successful() {
+        String token = "Bearer abcdef";
+        JwtResponse expected = new JwtResponse("access", "refresh", 1L, null);
+        when(jwtService.refreshToken("abcdef")).thenReturn(expected);
+
+        JwtResponse response = authService.refreshToken(token);
+
+        assertEquals("access", response.accessToken());
+    }
+
+    @Test
+    void changePassword_successful() {
+        Long userId = 1L;
+        RequestChangePasswordDto dto = new RequestChangePasswordDto("oldPass", "newPass");
+
+        User user = new User();
+        user.setPassword("encodedOld");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("oldPass", "encodedOld")).thenReturn(true);
+        when(passwordEncoder.encode("newPass")).thenReturn("encodedNew");
+
+        authService.changePassword(userId, dto);
+
+        verify(userRepository).save(argThat(savedUser -> savedUser.getPassword().equals("encodedNew")));
+    }
+
+    @Test
+    void changePassword_invalidCurrentPassword() {
+        Long userId = 1L;
+        RequestChangePasswordDto dto = new RequestChangePasswordDto("wrongPass", "newPass");
+
+        User user = new User();
+        user.setPassword("encodedOld");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("wrongPass", "encodedOld")).thenReturn(false);
+
+        assertThrows(InvalidPassword.class, () -> authService.changePassword(userId, dto));
+    }
+
+    @Test
+    void changePassword_userNotFound() {
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThrows(NotFoundException.class, () -> authService.changePassword(userId, new RequestChangePasswordDto("a", "b")));
+    }
+
+    @Test
+    void deleteUser_successful() {
+        Long userId = 1L;
+        authService.deleteUser(userId);
+        verify(userRepository).deleteById(userId);
+    }
+}

--- a/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/AuthServiceImplTest.java
+++ b/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/AuthServiceImplTest.java
@@ -54,18 +54,22 @@ class AuthServiceImplTest {
         request.setFirstName("John");
         request.setLastName("Doe");
         request.setPhone("+79991234567");
-
         when(userRepository.findByUsername("test@mail.com")).thenReturn(Optional.empty());
         when(passwordEncoder.encode("Password1")).thenReturn("hashedPassword");
-
+        User savedUser = new User();
+        savedUser.setId(1L);
+        savedUser.setUsername("test@mail.com");
+        savedUser.setPassword("hashedPassword");
+        when(userRepository.save(any(User.class))).thenReturn(savedUser);
         authService.register(request);
-
         verify(userRepository).save(argThat(user ->
                 user.getUsername().equals("test@mail.com") &&
                         user.getPassword().equals("hashedPassword")
         ));
         verify(eventPublisher).publish(any(UserCreatedDto.class));
     }
+
+
 
     @Test
     void register_userAlreadyExists() {

--- a/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/JwtServiceImplTest.java
+++ b/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/JwtServiceImplTest.java
@@ -1,0 +1,127 @@
+package com.cherkizon.auth.service.impl;
+
+import com.cherkizon.auth.dto.response.JwtResponse;
+import com.cherkizon.auth.entity.Token;
+import com.cherkizon.auth.entity.User;
+import com.cherkizon.auth.entity.User.Role;
+import com.cherkizon.auth.exception.InvalidTokenException;
+import com.cherkizon.auth.repository.TokenRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(org.mockito.junit.jupiter.MockitoExtension.class)
+class JwtServiceImplTest {
+
+    @InjectMocks
+    private JwtServiceImpl jwtService;
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    private final String secret = Base64.getEncoder()
+            .encodeToString("superSecretKeyForJwtTesting1234567890!@".getBytes(StandardCharsets.UTF_8));
+    private final long accessExpiration = 1000 * 60 * 15;
+    private final long refreshExpiration = 1000 * 60 * 60 * 24;
+
+    private User user;
+
+    @BeforeEach
+    void setup() {
+        ReflectionTestUtils.setField(jwtService, "secret", secret);
+        ReflectionTestUtils.setField(jwtService, "accessExpiration", accessExpiration);
+        ReflectionTestUtils.setField(jwtService, "refreshExpiration", refreshExpiration);
+
+        user = new User(1L, "john_doe", "hashed_password", Role.USER, new ArrayList<>());
+    }
+
+    @Test
+    void generateTokens_shouldReturnValidJwtResponse() {
+        JwtResponse response = jwtService.generateTokens(user);
+
+        assertNotNull(response.accessToken());
+        assertNotNull(response.refreshToken());
+        assertEquals(user.getId(), response.userId());
+        assertTrue(response.expiresAt().isAfter(Instant.now()));
+    }
+
+    @Test
+    void refreshToken_shouldReturnNewTokens_whenValid() throws InterruptedException {
+        JwtResponse oldTokens = jwtService.generateTokens(user);
+        String oldAccessToken = oldTokens.accessToken();
+        String oldRefreshToken = oldTokens.refreshToken();
+        String hashedToken = "encoded_token";
+        Instant validUntil = Instant.now().plusSeconds(3600);
+        Token dbToken = Token.builder()
+                .id(10L)
+                .user(user)
+                .refreshToken(hashedToken)
+                .expiresAt(validUntil)
+                .build();
+        when(tokenRepository.findAllByUserId(user.getId())).thenReturn(List.of(dbToken));
+        when(passwordEncoder.matches(oldRefreshToken, hashedToken)).thenReturn(true);
+        when(passwordEncoder.encode(anyString())).thenReturn("new_encoded_token");
+        Thread.sleep(50);
+        JwtResponse newTokens = jwtService.refreshToken(oldRefreshToken);
+        assertNotNull(newTokens);
+        assertNotEquals(oldAccessToken, newTokens.accessToken(), "Access tokens should be different after refresh");
+        assertNotEquals(oldRefreshToken, newTokens.refreshToken(), "Refresh tokens should be different after refresh");
+        verify(tokenRepository).delete(dbToken);
+        verify(tokenRepository).save(any(Token.class));
+    }
+
+
+    @Test
+    void refreshToken_shouldThrow_whenTokenNotInDb() {
+        JwtResponse oldTokens = jwtService.generateTokens(user);
+        String rawRefreshToken = oldTokens.refreshToken();
+
+        when(tokenRepository.findAllByUserId(user.getId())).thenReturn(List.of());
+
+        InvalidTokenException ex = assertThrows(InvalidTokenException.class,
+                () -> jwtService.refreshToken(rawRefreshToken));
+        assertEquals("Refresh token not found or invalid", ex.getMessage());
+    }
+
+    @Test
+    void refreshToken_shouldThrow_whenTokenExpiredInDb() {
+        JwtResponse oldTokens = jwtService.generateTokens(user);
+        String rawRefreshToken = oldTokens.refreshToken();
+
+        String hashedToken = "encoded_token";
+        Instant expiredAt = Instant.now().minusSeconds(10);
+
+        Token dbToken = Token.builder()
+                .user(user)
+                .refreshToken(hashedToken)
+                .expiresAt(expiredAt)
+                .build();
+
+        when(tokenRepository.findAllByUserId(user.getId())).thenReturn(List.of(dbToken));
+        when(passwordEncoder.matches(rawRefreshToken, hashedToken)).thenReturn(true);
+
+        assertThrows(InvalidTokenException.class, () -> jwtService.refreshToken(rawRefreshToken));
+        verify(tokenRepository).delete(dbToken);
+    }
+
+    @Test
+    void extractUserId_shouldReturnCorrectUserId() {
+        JwtResponse response = jwtService.generateTokens(user);
+        Long extracted = jwtService.extractUserId(response.accessToken());
+
+        assertEquals(user.getId(), extracted);
+    }
+}

--- a/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/JwtServiceImplTest.java
+++ b/backend/auth-service/src/test/java/com/cherkizon/auth/service/impl/JwtServiceImplTest.java
@@ -34,15 +34,15 @@ class JwtServiceImplTest {
 
     private final String secret = Base64.getEncoder()
             .encodeToString("superSecretKeyForJwtTesting1234567890!@".getBytes(StandardCharsets.UTF_8));
-    private final long accessExpiration = 1000 * 60 * 15;
-    private final long refreshExpiration = 1000 * 60 * 60 * 24;
 
     private User user;
 
     @BeforeEach
     void setup() {
         ReflectionTestUtils.setField(jwtService, "secret", secret);
+        long accessExpiration = 1000 * 60 * 15;
         ReflectionTestUtils.setField(jwtService, "accessExpiration", accessExpiration);
+        long refreshExpiration = 1000 * 60 * 60 * 24;
         ReflectionTestUtils.setField(jwtService, "refreshExpiration", refreshExpiration);
 
         user = new User(1L, "john_doe", "hashed_password", Role.USER, new ArrayList<>());
@@ -74,7 +74,7 @@ class JwtServiceImplTest {
         when(tokenRepository.findAllByUserId(user.getId())).thenReturn(List.of(dbToken));
         when(passwordEncoder.matches(oldRefreshToken, hashedToken)).thenReturn(true);
         when(passwordEncoder.encode(anyString())).thenReturn("new_encoded_token");
-        Thread.sleep(50);
+        Thread.sleep(1000);
         JwtResponse newTokens = jwtService.refreshToken(oldRefreshToken);
         assertNotNull(newTokens);
         assertNotEquals(oldAccessToken, newTokens.accessToken(), "Access tokens should be different after refresh");


### PR DESCRIPTION
#160 

добавил юнит-тесты для AuthServiceImpl и JwtServiceImpl;
Падает один тест:
-register_successful;

предполагаю  в процессе регистрации объект User не получает ID и он не устанавливается корректно, поэтому его значение null, при попытке использовать user.getId();
пока пытаюсь разобраться 
